### PR TITLE
removing extra domain certificate for "git."

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,9 +29,7 @@ func expect(target, err error) {
 
 // {
 //         "dev.01-edu.org": "all_caddy_1:8080",
-//     "git.dev.01-edu.org": "all_caddy_1:8081",
 //        "test.01-edu.org": "test01-eduorg_caddy_1:8080",
-//    "git.test.01-edu.org": "test01-eduorg_caddy_1:8081",
 // }
 var proxies = map[string]string{}
 

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,6 @@ DOMAIN=${DOMAIN:-dev.01-edu.org}
 
 if test "$(dig +short "$DOMAIN")" = "127.0.0.1"; then
     mkcert -cert-file "certs/${DOMAIN}-cert.pem"     -key-file "certs/${DOMAIN}-key.pem"     "${DOMAIN}"
-    # mkcert -cert-file "certs/git.${DOMAIN}-cert.pem" -key-file "certs/git.${DOMAIN}-key.pem" "git.${DOMAIN}"
 fi
 
 docker build -t https .

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@ DOMAIN=${DOMAIN:-dev.01-edu.org}
 
 if test "$(dig +short "$DOMAIN")" = "127.0.0.1"; then
     mkcert -cert-file "certs/${DOMAIN}-cert.pem"     -key-file "certs/${DOMAIN}-key.pem"     "${DOMAIN}"
-    mkcert -cert-file "certs/git.${DOMAIN}-cert.pem" -key-file "certs/git.${DOMAIN}-key.pem" "git.${DOMAIN}"
+    # mkcert -cert-file "certs/git.${DOMAIN}-cert.pem" -key-file "certs/git.${DOMAIN}-key.pem" "git.${DOMAIN}"
 fi
 
 docker build -t https .


### PR DESCRIPTION
This PR is derivative of <https://github.com/01-edu/all/pull/1128>

The main focus of the changes implemented here is to remove the `git.` domain, since we are now using the `gitea` as a sub path / route of our domain.

We use the certificates to redirect the user from `git.` to `/git` so this PR should be merged when the schools are used to the new replacement of gitea
